### PR TITLE
Add gem file lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,3 @@ Thumbs.db
 
 # Ignore Visual Studio Code files
 .vscode
-
-# Ignore Gemfile.lock
-Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,131 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
+    bootstrap (5.3.8)
+      popper_js (>= 2.11.8, < 3)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.3)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.34.0)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.0-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.0-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.0-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.0-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-archives (2.3.0)
+      jekyll (>= 3.6, < 5.0)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.18.1)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    minima (2.5.2)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    popper_js (2.11.8)
+    public_suffix (6.0.2)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.97.3)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.97.3-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  bootstrap (~> 5.3)
+  jekyll (~> 4.0)
+  jekyll-archives (~> 2.3)
+  jekyll-feed (~> 0.6)
+  minima (~> 2.0)
+  rexml
+  webrick
+
+BUNDLED WITH
+   2.6.9

--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ exclude:
 sass:
   quiet_deps: true
   load_paths:
-    - /home/runner/work/Jekyll-Theme-Verdant/Jekyll-Theme-Verdant/vendor/bundle/ruby/3.1.0/gems/bootstrap-5.3.5/assets/stylesheets
+    - /home/runner/work/Jekyll-Theme-Verdant/Jekyll-Theme-Verdant/vendor/bundle/ruby/3.1.0/gems/bootstrap-5.3.8/assets/stylesheets
 
 jekyll-archives:
   enabled:

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -23,7 +23,7 @@ exclude:
 sass:
   quiet_deps: true
   load_paths:
-    - /usr/local/bundle/gems/bootstrap-5.3.5/assets/stylesheets
+    - /usr/local/bundle/gems/bootstrap-5.3.8/assets/stylesheets
 
 jekyll-archives:
   enabled:


### PR DESCRIPTION
Add Gemfile.lock. 
The bootstrap version in the Gemfile was causing issues when running Docker Compose for the first time. The loadpath to Bootstrap has a specific version in the config files.